### PR TITLE
Fix Subscription Full example code in the Documentation

### DIFF
--- a/docs/pages/Subscription.rst
+++ b/docs/pages/Subscription.rst
@@ -47,8 +47,8 @@ has more properties to give you more fine-grained control.
 .. code-block:: qml
   :linenos:
 
-  Subscriber {
-    id: mySubscriber
+  Subscription {
+    id: mySubscription
     topic: "/intval"
     // Using messageType sets the type explicitly, will not connect to a
     //  publisher if the type does not match


### PR DESCRIPTION
I have corrected the error in the full example code on the Subscription page of the Documentation.