### PR TITLE
QoS wrapper to set Quality of Service settings for Publishers, Subscriptions and Services

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ set(SOURCES
   include/qml_ros2_plugin/logger.hpp
   include/qml_ros2_plugin/publisher.hpp
   include/qml_ros2_plugin/qobject_ros2.hpp
+  include/qml_ros2_plugin/qos.hpp
   include/qml_ros2_plugin/ros2.hpp
   include/qml_ros2_plugin/ros2_init_options.hpp
   include/qml_ros2_plugin/service_client.hpp
@@ -66,6 +67,7 @@ set(SOURCES
   src/publisher.cpp
   src/qml_ros2_plugin.cpp
   src/qobject_ros2.cpp
+  src/qos.cpp
   src/ros2.cpp
   src/ros2_init_options.cpp
   src/service_client.cpp

--- a/docs/pages/Examples.rst
+++ b/docs/pages/Examples.rst
@@ -5,17 +5,17 @@ Examples
 You can find the described example QML files in the
 `qml_ros2_plugin repo examples directory <https://github.com/StefanFabian/qml_ros2_plugin/tree/master/examples>`_.
 
-Subscriber
+Subscription
 ==========
 
-The subscriber example demonstrates how to create a ``Subscriber`` in QML
+The subscriber example demonstrates how to create a ``Subscription`` in QML
 using the *QML ROS Plugin*.
 
 You can run the example using the ``qmlscene`` executable:
 
 .. code-block::
 
-  qmlscene subscriber.qml
+  qmlscene subscription.qml
 
 Publisher
 =========

--- a/docs/pages/Publishers.rst
+++ b/docs/pages/Publishers.rst
@@ -21,7 +21,7 @@ created using a factory method of the Ros2 singleton.
   }
 
 In order, the arguments are the ``topic``, the ``type`` and the ``qos``.
-For backward compatibility and convenience, you can also pass an integer which will set the `history_policy` of the QoS to
+For backward compatibility and convenience, you can also pass an integer which will set the ``history_policy`` of the QoS to
 ``keep_last`` and the ``depth`` to the integer value.
 If you only pass the topic and type, the default QoS will be used which are best effort, durability volatile and depth 1.
 See the Ros2 singleton for different preconfigured QoS profiles.

--- a/docs/pages/Publishers.rst
+++ b/docs/pages/Publishers.rst
@@ -17,10 +17,14 @@ created using a factory method of the Ros2 singleton.
   ApplicationWindow {
     property var intPublisher: Ros2.createPublisher("/intval", "example_interfaces/msg/Int32", 10)
     /* ... */
+    property var intTransientLocalPublisher: Ros2.createPublisher("/intval_tl", "example_interfaces/msg/Int32", Ros2.QoS().transient_local())
   }
 
-In order, the arguments are the ``topic``, the ``type`` and the ``queueSize`` (defaults to 1).
-Additional QoS options are currently not supported.
+In order, the arguments are the ``topic``, the ``type`` and the ``qos``.
+For backward compatibility and convenience, you can also pass an integer which will set the `history_policy` of the QoS to
+``keep_last`` and the ``depth`` to the integer value.
+If you only pass the topic and type, the default QoS will be used which are best effort, durability volatile and depth 1.
+See the Ros2 singleton for different preconfigured QoS profiles.
 
 To publish a message using our Publisher, we can simply use the ``intPublisher`` variable defined earlier.
 
@@ -46,4 +50,7 @@ API
 Publisher
 =========
 .. doxygenclass:: qml_ros2_plugin::Publisher
+  :members:
+
+.. doxygenclass:: qml_ros2_plugin::QoSWrapper
   :members:

--- a/docs/pages/Ros2-Singleton.rst
+++ b/docs/pages/Ros2-Singleton.rst
@@ -131,5 +131,8 @@ API
 .. doxygenclass:: qml_ros2_plugin::IO
   :members:
 
+.. doxygenclass:: qml_ros2_plugin::QoSWrapper
+  :members:
+
 .. doxygenclass:: qml_ros2_plugin::Ros2QmlSingletonWrapper
   :members:

--- a/docs/pages/Subscription.rst
+++ b/docs/pages/Subscription.rst
@@ -60,8 +60,8 @@ has more properties to give you more fine-grained control.
     onNewMessage: doStuff(message)
   }
 
-Note that due to the ``throttleRate`` messages may be dropped even if the ``qos`` is changed to keep more than 1.
-To avoid this, set the throttleRate to 0.
+Note that due to the ``throttleRate``, messages may be dropped even if the ``qos`` is changed to keep more than 1.
+To avoid this, if you want to process all received messages up to the ``keep_last`` history depth, set the throttleRate to 0.
 
 The ``throttleRate`` limits the rate in which QML receives updates from the given topic.
 By default the Subscriber polls with 20 Hz on the UI thread and will notify of property changes

--- a/docs/pages/Subscription.rst
+++ b/docs/pages/Subscription.rst
@@ -54,14 +54,14 @@ has more properties to give you more fine-grained control.
     //  publisher if the type does not match
     messageType: "example_interfaces/msg/Int32"
     throttleRate: 30 // Update rate of message property in Hz. Default: 20
-    queueSize: 10
+    // QoS settings, defaults to best_effort, durability_volatile and history depth of 1
+    qos: Ros2.QoS().reliable().transient_local().keep_last(10)
     enabled: true // Can be used to pause/unpause the subscription
     onNewMessage: doStuff(message)
   }
 
-The ``queueSize`` property controls how many incoming messages are queued for
-processing before the oldest are dropped.
-Note that due to the ``throttleRate`` messages may be dropped even if the ``queueSize`` is large enough.
+Note that due to the ``throttleRate`` messages may be dropped even if the ``qos`` is changed to keep more than 1.
+To avoid this, set the throttleRate to 0.
 
 The ``throttleRate`` limits the rate in which QML receives updates from the given topic.
 By default the Subscriber polls with 20 Hz on the UI thread and will notify of property changes

--- a/include/qml_ros2_plugin/goal_handle.hpp
+++ b/include/qml_ros2_plugin/goal_handle.hpp
@@ -22,8 +22,11 @@ class GoalHandle : public QObjectRos2
   Q_PROPERTY( QString goalId READ goalId )
   Q_PROPERTY( qml_ros2_plugin::Time goalStamp READ goalStamp )
 public:
-  explicit GoalHandle( ros_babel_fish::BabelFishActionClient::SharedPtr client,
-                       ros_babel_fish::BabelFishActionClient::GoalHandle::SharedPtr handle );
+  GoalHandle( ros_babel_fish::BabelFishActionClient::SharedPtr client,
+              ros_babel_fish::BabelFishActionClient::GoalHandle::SharedPtr handle );
+
+  GoalHandle( ros_babel_fish::BabelFishActionClient::SharedPtr client,
+              std::shared_future<ros_babel_fish::BabelFishActionClient::GoalHandle::SharedPtr> handle );
 
   qml_ros2_plugin::action_goal_status::GoalStatus status() const;
 
@@ -38,10 +41,13 @@ protected:
   void onRos2Shutdown() override;
 
 private:
+  void checkFuture() const;
+
   ros_babel_fish::BabelFish babel_fish_;
   // Store the client to make sure its destructed after the goal handles
   ros_babel_fish::BabelFishActionClient::SharedPtr client_;
-  ros_babel_fish::BabelFishActionClient::GoalHandle::SharedPtr goal_handle_;
+  mutable ros_babel_fish::BabelFishActionClient::GoalHandle::SharedPtr goal_handle_;
+  mutable std::shared_future<ros_babel_fish::BabelFishActionClient::GoalHandle::SharedPtr> goal_handle_future_;
 };
 } // namespace qml_ros2_plugin
 

--- a/include/qml_ros2_plugin/publisher.hpp
+++ b/include/qml_ros2_plugin/publisher.hpp
@@ -5,6 +5,7 @@
 #define QML_ROS2_PLUGIN_PUBLISHER_HPP
 
 #include "qml_ros2_plugin/qobject_ros2.hpp"
+#include "qml_ros2_plugin/qos.hpp"
 #include <QMap>
 #include <QTimer>
 #include <QVariant>
@@ -21,13 +22,15 @@ class Publisher : public QObjectRos2
   Q_PROPERTY( QString type READ type )
   //! The topic this Publisher publishes messages on. This property is only valid if the publisher is already advertised! (readonly)
   Q_PROPERTY( QString topic READ topic )
-  //! The queue size of this Publisher. This is the maximum number of messages that are queued for delivery to subscribers at a time. (readonly)
+  //! The queue size of this Publisher. This is the depth if the history policy of the QoS is set to keep_last. (readonly)
   Q_PROPERTY( quint32 queueSize READ queueSize )
+  //! The Quality of Service settings of this publisher.
+  Q_PROPERTY( QoSWrapper qos READ qos )
   //! Whether or not this publisher has advertised its existence on its topic.
   //! Reasons for not being advertised include ROS not being initialized yet. (readonly)
   Q_PROPERTY( bool isAdvertised READ isAdvertised NOTIFY advertised )
 public:
-  Publisher( QString topic, QString type, uint32_t queue_size );
+  Publisher( QString topic, QString type, const QoSWrapper &qos );
 
   ~Publisher() override;
 
@@ -36,6 +39,8 @@ public:
   const QString &type() const;
 
   quint32 queueSize() const;
+
+  const QoSWrapper &qos() const;
 
   bool isAdvertised() const;
 
@@ -68,12 +73,12 @@ protected:
   QTimer advertise_timer_;
   ros_babel_fish::BabelFish babel_fish_;
   ros_babel_fish::BabelFishPublisher::SharedPtr publisher_;
+  QoSWrapper qos_;
 
-  bool is_advertised_;
   QString type_;
   std::string std_type_;
   QString topic_;
-  uint32_t queue_size_;
+  bool is_advertised_;
 };
 } // namespace qml_ros2_plugin
 

--- a/include/qml_ros2_plugin/qos.hpp
+++ b/include/qml_ros2_plugin/qos.hpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2025 Stefan Fabian. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef QML_ROS2_PLUGIN_QOS_HPP
+#define QML_ROS2_PLUGIN_QOS_HPP
+
+#include <QObject>
+#include <QString>
+
+#include <rclcpp/qos.hpp>
+
+namespace qml_ros2_plugin
+{
+
+//! @brief Wrapper to enable setting QoS settings in QML.
+//! Defaults to 1 depth, best effort reliability and volatile durability.
+class QoSWrapper
+{
+  Q_GADGET
+public:
+  QoSWrapper();
+  explicit QoSWrapper( rclcpp::QoS qos );
+
+  //! @brief Sets the reliability policy to reliable. Returns the QoSWrapper for chaining.
+  Q_INVOKABLE qml_ros2_plugin::QoSWrapper reliable();
+
+  //! @brief Sets the reliability policy to best effort. Returns the QoSWrapper for chaining.
+  Q_INVOKABLE qml_ros2_plugin::QoSWrapper best_effort();
+
+  //! @brief Sets the durability policy to volatile. Returns the QoSWrapper for chaining.
+  Q_INVOKABLE qml_ros2_plugin::QoSWrapper durability_volatile();
+
+  //! @brief Sets the durability policy to transient local. Returns the QoSWrapper for chaining.
+  Q_INVOKABLE qml_ros2_plugin::QoSWrapper transient_local();
+
+  //! @brief Sets the history policy to keep all messages. Returns the QoSWrapper for chaining.
+  Q_INVOKABLE qml_ros2_plugin::QoSWrapper keep_all();
+
+  //! @brief Sets the history policy to keep last messages. Returns the QoSWrapper for chaining.
+  //! @param depth The number of messages to keep.
+  Q_INVOKABLE qml_ros2_plugin::QoSWrapper keep_last( int depth );
+
+  //! @brief Returns the depth of the QoS policy. If history policy is set to keep_last, this is the
+  //!        number of messages to keep.
+  Q_INVOKABLE int depth() const;
+
+  const rclcpp::QoS &rclcppQoS() const { return qos_; }
+
+  std::string toString() const;
+
+private:
+  rclcpp::QoS qos_;
+};
+
+} // namespace qml_ros2_plugin
+
+Q_DECLARE_METATYPE( qml_ros2_plugin::QoSWrapper )
+
+#endif // QML_ROS2_PLUGIN_QOS_HPP

--- a/include/qml_ros2_plugin/ros2.hpp
+++ b/include/qml_ros2_plugin/ros2.hpp
@@ -6,6 +6,7 @@
 
 #include "qml_ros2_plugin/io.hpp"
 #include "qml_ros2_plugin/logger.hpp"
+#include "qml_ros2_plugin/qos.hpp"
 #include "qml_ros2_plugin/ros2_init_options.hpp"
 #include "qml_ros2_plugin/time.hpp"
 #include "qml_ros2_plugin/topic_info.hpp"
@@ -180,6 +181,25 @@ public:
   //! Create a Ros2InitOptions object.
   Q_INVOKABLE QObject *createInitOptions();
 
+  //! Creates a default QoS object with Stefan Fabian's recommended settings for UIs:
+  //! best_effort and volatile with a history depth of 1.
+  Q_INVOKABLE qml_ros2_plugin::QoSWrapper QoS();
+
+  //! Creates a QoS wrapper with the settings for BestAvailable from rclcpp.
+  Q_INVOKABLE qml_ros2_plugin::QoSWrapper BestAvailableQoS();
+
+  //! Creates a QoS wrapper with the settings for Clock from rclcpp.
+  Q_INVOKABLE qml_ros2_plugin::QoSWrapper ClockQoS();
+
+  //! Creates a QoS wrapper with the settings for SensorData from rclcpp.
+  Q_INVOKABLE qml_ros2_plugin::QoSWrapper SensorDataQoS();
+
+  //! Creates a QoS wrapper with the settings for Services from rclcpp.
+  Q_INVOKABLE qml_ros2_plugin::QoSWrapper ServicesQoS();
+
+  //! Creates a QoS wrapper with the settings for SystemDefaults from rclcpp.
+  Q_INVOKABLE qml_ros2_plugin::QoSWrapper SystemDefaultsQoS();
+
   //! @copydoc Ros2Qml::isRosInitialized
   Q_INVOKABLE bool isInitialized() const;
 
@@ -268,19 +288,32 @@ public:
    *
    * @param type The type of the messages published using this publisher.
    * @param topic The topic on which the messages are published.
-   * @param queue_size The maximum number of outgoing messages to be queued for delivery to subscribers.
    * @return A Publisher instance.
    */
   Q_INVOKABLE QObject *createPublisher( const QString &topic, const QString &type,
-                                        quint32 queue_size = 1 );
+                                        const qml_ros2_plugin::QoSWrapper &qos = {} );
+
+  /*!
+   * @see createPublisher(const QString &, const QString &, const qml_ros2_plugin::QoSWrapper &)
+   * @param queue_size Sets the keep_last history of the qos to the given value.
+   */
+  Q_INVOKABLE QObject *createPublisher( const QString &topic, const QString &type,
+                                        quint32 queue_size );
 
   /*!
    * Creates a Subscriber to createSubscription to ROS messages.
    * Convenience function to create a subscriber in a single line.
    *
    * @param topic The topic to createSubscription to.
-   * @param queue_size The maximum number of incoming messages to be queued for processing.
+   * @param qos The QoS settings for the subscription.
    * @return A Subscriber instance.
+   */
+  Q_INVOKABLE QObject *createSubscription( const QString &topic,
+                                           const qml_ros2_plugin::QoSWrapper &qos );
+
+  /*!
+   * @see createSubscription(const QString &, const qml_ros2_plugin::QoSWrapper &)
+   * @param queue_size The keep_last history of the qos. Default: 1
    */
   Q_INVOKABLE QObject *createSubscription( const QString &topic, quint32 queue_size = 1 );
 
@@ -294,6 +327,13 @@ public:
    * @return A Subscriber instance.
    */
   Q_INVOKABLE QObject *createSubscription( const QString &topic, const QString &message_type,
+                                           const qml_ros2_plugin::QoSWrapper &qos );
+
+  /*!
+   * @see createSubscription(const QString &, const QString &, const qml_ros2_plugin::QoSWrapper &)
+   * @param queue_size The keep_last history of the qos. Default: 1
+   */
+  Q_INVOKABLE QObject *createSubscription( const QString &topic, const QString &message_type,
                                            quint32 queue_size = 1 );
 
   /*!
@@ -303,6 +343,13 @@ public:
    * @return An instance of ServiceClient.
    */
   Q_INVOKABLE QObject *createServiceClient( const QString &name, const QString &type );
+
+  /*!
+   * @copydoc createServiceClient(const QString &, const QString &)
+   * @param qos The QoS settings for the service client.
+   */
+  Q_INVOKABLE QObject *createServiceClient( const QString &name, const QString &type,
+                                            const qml_ros2_plugin::QoSWrapper &qos );
 
   /*!
    * Creates an ActionClient for the given type and the given name.

--- a/include/qml_ros2_plugin/ros2.hpp
+++ b/include/qml_ros2_plugin/ros2.hpp
@@ -291,14 +291,14 @@ public:
    * @return A Publisher instance.
    */
   Q_INVOKABLE QObject *createPublisher( const QString &topic, const QString &type,
-                                        const qml_ros2_plugin::QoSWrapper &qos = {} );
+                                        const qml_ros2_plugin::QoSWrapper &qos );
 
   /*!
    * @see createPublisher(const QString &, const QString &, const qml_ros2_plugin::QoSWrapper &)
    * @param queue_size Sets the keep_last history of the qos to the given value.
    */
   Q_INVOKABLE QObject *createPublisher( const QString &topic, const QString &type,
-                                        quint32 queue_size );
+                                        quint32 queue_size = 10 );
 
   /*!
    * Creates a Subscriber to createSubscription to ROS messages.

--- a/include/qml_ros2_plugin/service_client.hpp
+++ b/include/qml_ros2_plugin/service_client.hpp
@@ -5,6 +5,7 @@
 #define QML_ROS2_PLUGIN_SERVICE_CLIENT_HPP
 
 #include "qml_ros2_plugin/qobject_ros2.hpp"
+#include "qml_ros2_plugin/qos.hpp"
 #include <QJSValue>
 #include <QTimer>
 #include <QVariant>
@@ -28,7 +29,7 @@ public:
    * @param name The service topic.
    * @param type The type of the service, e.g., "example_interfaces/srv/AddTwoInts"
    */
-  ServiceClient( QString name, QString type );
+  ServiceClient( QString name, QString type, const QoSWrapper &qos = {} );
 
   //! Returns whether the service is ready.
   bool isServiceReady() const;
@@ -64,6 +65,7 @@ private slots:
 
 private:
   ros_babel_fish::BabelFish babel_fish_;
+  QoSWrapper qos_;
   QString name_;
   QString service_type_;
   ros_babel_fish::BabelFishServiceClient::SharedPtr client_;

--- a/include/qml_ros2_plugin/service_client.hpp
+++ b/include/qml_ros2_plugin/service_client.hpp
@@ -29,7 +29,8 @@ public:
    * @param name The service topic.
    * @param type The type of the service, e.g., "example_interfaces/srv/AddTwoInts"
    */
-  ServiceClient( QString name, QString type, const QoSWrapper &qos = {} );
+  ServiceClient( QString name, QString type,
+                 const QoSWrapper &qos = QoSWrapper( rclcpp::ServicesQoS() ) );
 
   //! Returns whether the service is ready.
   bool isServiceReady() const;

--- a/include/qml_ros2_plugin/subscription.hpp
+++ b/include/qml_ros2_plugin/subscription.hpp
@@ -36,8 +36,8 @@ class Subscription : public QObjectRos2
   //! automatically detected and if the topic has multiple available types, one is arbitrarily selected.
   Q_PROPERTY( QString messageType READ messageType WRITE setMessageType NOTIFY messageTypeChanged )
 
-  //! Limits the frequency in which the notification for an updated message is emitted. Default: 20 Hz
-  //! Set to 0 to disable throttling and receive all messages.
+  //! Limits the frequency in which the notification for an updated message is emitted.
+  //! Set to 0 to disable throttling and receive all messages.  Default: 20Hz
   Q_PROPERTY( int throttleRate READ throttleRate WRITE setThrottleRate NOTIFY throttleRateChanged )
 
   //! Controls whether or not the subscriber is currently enabled, i.e., able to receive messages. Default: true

--- a/include/qml_ros2_plugin/subscription.hpp
+++ b/include/qml_ros2_plugin/subscription.hpp
@@ -37,6 +37,7 @@ class Subscription : public QObjectRos2
   Q_PROPERTY( QString messageType READ messageType WRITE setMessageType NOTIFY messageTypeChanged )
 
   //! Limits the frequency in which the notification for an updated message is emitted. Default: 20 Hz
+  //! Set to 0 to disable throttling and receive all messages.
   Q_PROPERTY( int throttleRate READ throttleRate WRITE setThrottleRate NOTIFY throttleRateChanged )
 
   //! Controls whether or not the subscriber is currently enabled, i.e., able to receive messages. Default: true
@@ -128,7 +129,7 @@ protected:
   QTimer subscribe_timer_;
   ros_babel_fish::BabelFish babel_fish_;
   ros_babel_fish::BabelFishSubscription::SharedPtr subscription_;
-  ros_babel_fish::CompoundMessage::ConstSharedPtr last_message_;
+  std::vector<ros_babel_fish::CompoundMessage::ConstSharedPtr> message_queue_;
   std::mutex message_mutex_;
   QTimer throttle_timer_;
 

--- a/include/qml_ros2_plugin/subscription.hpp
+++ b/include/qml_ros2_plugin/subscription.hpp
@@ -5,6 +5,7 @@
 #define QML_ROS2_PLUGIN_SUBSCRIPTION_HPP
 
 #include "qml_ros2_plugin/qobject_ros2.hpp"
+#include "qml_ros2_plugin/qos.hpp"
 
 #include <QMap>
 #include <QTimer>
@@ -25,6 +26,9 @@ class Subscription : public QObjectRos2
   //! The maximum number of messages that are queued for processing. Default: 10
   Q_PROPERTY( quint32 queueSize READ queueSize WRITE setQueueSize NOTIFY queueSizeChanged )
 
+  //! The QoS settings for this subscription. Use ``Ros2.QoS()`` to create QoS settings.
+  Q_PROPERTY( qml_ros2_plugin::QoSWrapper qos READ qos WRITE setQoS NOTIFY qosChanged )
+
   //! The last message that was received by this subscriber.
   Q_PROPERTY( QVariant message READ message NOTIFY messageChanged )
 
@@ -43,7 +47,7 @@ class Subscription : public QObjectRos2
 public:
   Subscription();
 
-  Subscription( QString topic, QString message_type, quint32 queue_size, bool enabled = true );
+  Subscription( QString topic, QString message_type, const QoSWrapper &qos, bool enabled = true );
 
   ~Subscription() override;
 
@@ -54,6 +58,10 @@ public:
   quint32 queueSize() const;
 
   void setQueueSize( quint32 value );
+
+  const QoSWrapper &qos() const;
+
+  void setQoS( const QoSWrapper &qos );
 
   bool enabled() const;
 
@@ -81,6 +89,8 @@ signals:
   void topicChanged();
 
   void queueSizeChanged();
+
+  void qosChanged();
 
   void throttleRateChanged();
 
@@ -122,11 +132,11 @@ protected:
   std::mutex message_mutex_;
   QTimer throttle_timer_;
 
+  QoSWrapper qos_;
   QString topic_;
   QString user_message_type_;
   QString message_type_;
   QVariant message_;
-  quint32 queue_size_ = 10;
   int throttle_rate_ = 20;
   bool running_ = true;
   bool is_subscribed_ = false;

--- a/src/action_client.cpp
+++ b/src/action_client.cpp
@@ -19,10 +19,9 @@ namespace qml_ros2_plugin
 {
 
 ActionClient::ActionClient( const QString &name, const QString &action_type )
+    : action_type_( action_type ), name_( name )
 {
   babel_fish_ = BabelFishDispenser::getBabelFish();
-  action_type_ = action_type;
-  name_ = name;
 }
 
 void ActionClient::onRos2Initialized()

--- a/src/action_client.cpp
+++ b/src/action_client.cpp
@@ -161,7 +161,7 @@ QObject *ActionClient::sendGoalAsync( const QVariantMap &goal, QJSValue options 
               Q_ARG( ros_babel_fish::CompoundMessage::ConstSharedPtr, result.result ) );
         };
     auto goal_handle = client_->async_send_goal( message, goal_options );
-    return nullptr; // TODO add promise or something like that
+    return new GoalHandle( client_, std::move( goal_handle ) );
   } catch ( BabelFishException &ex ) {
     QML_ROS2_PLUGIN_ERROR( "Failed to send Action goal: %s", ex.what() );
   }

--- a/src/goal_handle.cpp
+++ b/src/goal_handle.cpp
@@ -5,9 +5,11 @@
 
 #include "qml_ros2_plugin/babel_fish_dispenser.hpp"
 #include "qml_ros2_plugin/conversion/message_conversions.hpp"
+#include "qml_ros2_plugin/helpers/logging.hpp"
 
 using namespace ros_babel_fish;
 using namespace qml_ros2_plugin::conversion;
+using namespace std::chrono_literals;
 
 namespace qml_ros2_plugin
 {
@@ -19,15 +21,32 @@ GoalHandle::GoalHandle( BabelFishActionClient::SharedPtr client,
   babel_fish_ = BabelFishDispenser::getBabelFish();
 }
 
+GoalHandle::GoalHandle(
+    ros_babel_fish::BabelFishActionClient::SharedPtr client,
+    std::shared_future<ros_babel_fish::BabelFishActionClient::GoalHandle::SharedPtr> handle )
+    : client_( std::move( client ) ), goal_handle_future_( std::move( handle ) )
+{
+  babel_fish_ = BabelFishDispenser::getBabelFish();
+}
+
 void GoalHandle::cancel()
 {
   if ( client_ == nullptr )
     return;
+  if ( goal_handle_ == nullptr ) {
+    goal_handle_future_.wait_for( 100ms );
+    checkFuture();
+    if ( goal_handle_ == nullptr ) {
+      QML_ROS2_PLUGIN_ERROR( "GoalHandle::cancel() called but goal_handle is not ready." );
+      return;
+    }
+  }
   client_->async_cancel_goal( goal_handle_ );
 }
 
 qml_ros2_plugin::action_goal_status::GoalStatus GoalHandle::status() const
 {
+  checkFuture();
   if ( goal_handle_ == nullptr )
     return action_goal_status::Unknown;
   return static_cast<action_goal_status::GoalStatus>( goal_handle_->get_status() );
@@ -35,6 +54,7 @@ qml_ros2_plugin::action_goal_status::GoalStatus GoalHandle::status() const
 
 QString GoalHandle::goalId() const
 {
+  checkFuture();
   if ( goal_handle_ == nullptr )
     return {};
   return conversion::uuidToString( goal_handle_->get_goal_id() );
@@ -42,6 +62,7 @@ QString GoalHandle::goalId() const
 
 qml_ros2_plugin::Time GoalHandle::goalStamp() const
 {
+  checkFuture();
   if ( goal_handle_ == nullptr )
     return Time();
   return Time( goal_handle_->get_goal_stamp() );
@@ -52,4 +73,17 @@ void GoalHandle::onRos2Shutdown()
   client_ = nullptr;
   goal_handle_ = nullptr;
 }
+
+void GoalHandle::checkFuture() const
+{
+  if ( goal_handle_ != nullptr )
+    return;
+  if ( !goal_handle_future_.valid() )
+    return;
+  auto status = goal_handle_future_.wait_for( std::chrono::milliseconds( 0 ) );
+  if ( status == std::future_status::ready ) {
+    goal_handle_ = goal_handle_future_.get();
+  }
+}
+
 } // namespace qml_ros2_plugin

--- a/src/qml_ros2_plugin.cpp
+++ b/src/qml_ros2_plugin.cpp
@@ -8,6 +8,7 @@
 #include "qml_ros2_plugin/image_transport_subscription.hpp"
 #include "qml_ros2_plugin/logger.hpp"
 #include "qml_ros2_plugin/publisher.hpp"
+#include "qml_ros2_plugin/qos.hpp"
 #include "qml_ros2_plugin/ros2.hpp"
 #include "qml_ros2_plugin/service_client.hpp"
 #include "qml_ros2_plugin/subscription.hpp"
@@ -45,8 +46,7 @@ public:
     qmlRegisterUncreatableType<qml_ros2_plugin::Ros2InitOptions>(
         "Ros2", 1, 0, "Ros2InitOptions",
         "Error: Can not create Ros2InitOptions manually. A Ros2InitOptions is obtained as a return "
-        "value of "
-        "Ros2.createInitOptions()." );
+        "value of Ros2.createInitOptions()." );
     qmlRegisterSingletonType<Ros2QmlSingletonWrapper>(
         "Ros2", 1, 0, "Ros2", []( QQmlEngine *engine, QJSEngine *scriptEngine ) -> QObject * {
           Q_UNUSED( engine );
@@ -96,6 +96,7 @@ public:
         "Error: Can not create ServiceClient manually in QML. Use the "
         "Ros2.createServiceClient(name, type) factory method." );
 
+    qRegisterMetaType<QoSWrapper>();
     // Time
     qRegisterMetaType<Time>();
     qRegisterMetaType<Duration>();

--- a/src/qos.cpp
+++ b/src/qos.cpp
@@ -1,0 +1,115 @@
+// Copyright (c) 2025 Stefan Fabian. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "qml_ros2_plugin/qos.hpp"
+
+namespace qml_ros2_plugin
+{
+QoSWrapper::QoSWrapper() : qos_( 1 )
+{
+  qos_.best_effort();
+  qos_.durability_volatile();
+}
+
+QoSWrapper::QoSWrapper( rclcpp::QoS qos ) : qos_( qos ) { }
+
+QoSWrapper QoSWrapper::reliable()
+{
+  qos_.reliable();
+  return *this;
+}
+
+QoSWrapper QoSWrapper::best_effort()
+{
+  qos_.best_effort();
+  return *this;
+}
+
+QoSWrapper QoSWrapper::durability_volatile()
+{
+  qos_.durability_volatile();
+  return *this;
+}
+
+QoSWrapper QoSWrapper::transient_local()
+{
+  qos_.transient_local();
+  return *this;
+}
+
+QoSWrapper QoSWrapper::keep_all()
+{
+  qos_.keep_all();
+  return *this;
+}
+
+qml_ros2_plugin::QoSWrapper QoSWrapper::keep_last( int depth )
+{
+  qos_.keep_last( depth );
+  return *this;
+}
+
+int QoSWrapper::depth() const { return qos_.depth(); }
+
+namespace
+{
+std::string to_string( const rclcpp::ReliabilityPolicy &reliability )
+{
+  switch ( reliability ) {
+  case rclcpp::ReliabilityPolicy::BestEffort:
+    return "BestEffort";
+  case rclcpp::ReliabilityPolicy::Reliable:
+    return "Reliable";
+  case rclcpp::ReliabilityPolicy::SystemDefault:
+    return "SystemDefault";
+  case rclcpp::ReliabilityPolicy::BestAvailable:
+    return "BestAvailable";
+  case rclcpp::ReliabilityPolicy::Unknown:
+    return "Unknown";
+  }
+  return "Invalid";
+}
+
+std::string to_string( const rclcpp::DurabilityPolicy &durability )
+{
+  switch ( durability ) {
+  case rclcpp::DurabilityPolicy::Volatile:
+    return "Volatile";
+  case rclcpp::DurabilityPolicy::TransientLocal:
+    return "TransientLocal";
+  case rclcpp::DurabilityPolicy::SystemDefault:
+    return "SystemDefault";
+  case rclcpp::DurabilityPolicy::Unknown:
+    return "Unknown";
+  case rclcpp::DurabilityPolicy::BestAvailable:
+    return "BestAvailable";
+  }
+  return "Invalid";
+}
+
+std::string to_string( const rclcpp::HistoryPolicy &history )
+{
+  switch ( history ) {
+  case rclcpp::HistoryPolicy::KeepLast:
+    return "KeepLast";
+  case rclcpp::HistoryPolicy::KeepAll:
+    return "KeepAll";
+  case rclcpp::HistoryPolicy::SystemDefault:
+    return "SystemDefault";
+  case rclcpp::HistoryPolicy::Unknown:
+    return "Unknown";
+  }
+  return "Invalid";
+}
+} // namespace
+
+std::string QoSWrapper::toString() const
+{
+  std::string result = "QoS(";
+  result += "reliability: " + to_string( qos_.reliability() ) + ", ";
+  result += "durability: " + to_string( qos_.durability() ) + ", ";
+  result += "history: " + to_string( qos_.history() ) + ", ";
+  result += "depth: " + std::to_string( qos_.depth() ) + ")";
+  return result;
+}
+} // namespace qml_ros2_plugin

--- a/src/ros2.cpp
+++ b/src/ros2.cpp
@@ -518,7 +518,7 @@ QObject *Ros2QmlSingletonWrapper::createPublisher( const QString &topic, const Q
 QObject *Ros2QmlSingletonWrapper::createPublisher( const QString &topic, const QString &type,
                                                    quint32 queue_size )
 {
-  return createPublisher( topic, type, QoSWrapper().keep_last( queue_size ) );
+  return createPublisher( topic, type, QoSWrapper().reliable().keep_last( queue_size ) );
 }
 
 QObject *Ros2QmlSingletonWrapper::createSubscription( const QString &topic, const QoSWrapper &qos )

--- a/src/ros2.cpp
+++ b/src/ros2.cpp
@@ -7,6 +7,7 @@
 #include "qml_ros2_plugin/conversion/message_conversions.hpp"
 #include "qml_ros2_plugin/helpers/logging.hpp"
 #include "qml_ros2_plugin/publisher.hpp"
+#include "qml_ros2_plugin/qos.hpp"
 #include "qml_ros2_plugin/service_client.hpp"
 #include "qml_ros2_plugin/subscription.hpp"
 
@@ -322,6 +323,26 @@ QString Ros2QmlSingletonWrapper::hostname() const { return Ros2Qml::getInstance(
 
 QObject *Ros2QmlSingletonWrapper::createInitOptions() { return new Ros2InitOptions; }
 
+QoSWrapper Ros2QmlSingletonWrapper::QoS() { return {}; }
+
+QoSWrapper Ros2QmlSingletonWrapper::BestAvailableQoS()
+{
+  return QoSWrapper( rclcpp::BestAvailableQoS() );
+}
+QoSWrapper Ros2QmlSingletonWrapper::ClockQoS() { return QoSWrapper( rclcpp::ClockQoS() ); }
+
+QoSWrapper Ros2QmlSingletonWrapper::SensorDataQoS()
+{
+  return QoSWrapper( rclcpp::SensorDataQoS() );
+}
+
+QoSWrapper Ros2QmlSingletonWrapper::ServicesQoS() { return QoSWrapper( rclcpp::ServicesQoS() ); }
+
+QoSWrapper Ros2QmlSingletonWrapper::SystemDefaultsQoS()
+{
+  return QoSWrapper( rclcpp::SystemDefaultsQoS() );
+}
+
 bool Ros2QmlSingletonWrapper::isInitialized() const
 {
   return Ros2Qml::getInstance().isInitialized();
@@ -489,25 +510,49 @@ QJSValue Ros2QmlSingletonWrapper::fatal()
 }
 
 QObject *Ros2QmlSingletonWrapper::createPublisher( const QString &topic, const QString &type,
+                                                   const qml_ros2_plugin::QoSWrapper &qos )
+{
+  return new Publisher( topic, type, qos );
+}
+
+QObject *Ros2QmlSingletonWrapper::createPublisher( const QString &topic, const QString &type,
                                                    quint32 queue_size )
 {
-  return new Publisher( topic, type, queue_size );
+  return createPublisher( topic, type, QoSWrapper().keep_last( queue_size ) );
+}
+
+QObject *Ros2QmlSingletonWrapper::createSubscription( const QString &topic, const QoSWrapper &qos )
+{
+  return new Subscription( topic, QString(), qos );
 }
 
 QObject *Ros2QmlSingletonWrapper::createSubscription( const QString &topic, quint32 queue_size )
 {
-  return new Subscription( topic, QString(), queue_size );
+  return createSubscription( topic, QoSWrapper().keep_last( queue_size ) );
+}
+
+QObject *Ros2QmlSingletonWrapper::createSubscription( const QString &topic,
+                                                      const QString &message_type,
+                                                      const QoSWrapper &qos )
+{
+  return new Subscription( topic, message_type, qos );
 }
 
 QObject *Ros2QmlSingletonWrapper::createSubscription( const QString &topic,
                                                       const QString &message_type, quint32 queue_size )
 {
-  return new Subscription( topic, message_type, queue_size );
+  return createSubscription( topic, message_type, QoSWrapper().keep_last( queue_size ) );
 }
 
 QObject *Ros2QmlSingletonWrapper::createServiceClient( const QString &name, const QString &type )
 {
-  return new ServiceClient( name, type );
+  return createServiceClient( name, type, QoSWrapper( rclcpp::ServicesQoS() ) );
+}
+
+QObject *Ros2QmlSingletonWrapper::createServiceClient( const QString &name, const QString &type,
+                                                       const qml_ros2_plugin::QoSWrapper &qos )
+{
+  return new ServiceClient( name, type, qos );
 }
 
 QObject *Ros2QmlSingletonWrapper::createActionClient( const QString &name, const QString &type )

--- a/src/service_client.cpp
+++ b/src/service_client.cpp
@@ -15,8 +15,8 @@ using namespace qml_ros2_plugin::conversion;
 
 namespace qml_ros2_plugin
 {
-ServiceClient::ServiceClient( QString name, QString type )
-    : name_( std::move( name ) ), service_type_( std::move( type ) )
+ServiceClient::ServiceClient( QString name, QString type, const QoSWrapper &qos )
+    : qos_( qos ), name_( std::move( name ) ), service_type_( std::move( type ) )
 {
   babel_fish_ = BabelFishDispenser::getBabelFish();
 }
@@ -26,7 +26,8 @@ void ServiceClient::onRos2Initialized()
   try {
     rclcpp::Node &node = *Ros2Qml::getInstance().node();
     client_ =
-        babel_fish_.create_service_client( node, name_.toStdString(), service_type_.toStdString() );
+        babel_fish_.create_service_client( node, name_.toStdString(), service_type_.toStdString(),
+                                           qos_.rclcppQoS().get_rmw_qos_profile() );
   } catch ( BabelFishException &ex ) {
     QML_ROS2_PLUGIN_ERROR( "Could not create ServiceClient: %s", ex.what() );
     client_ = nullptr;

--- a/src/subscription.cpp
+++ b/src/subscription.cpp
@@ -139,7 +139,8 @@ void Subscription::subscribe()
 
   QML_ROS2_PLUGIN_DEBUG( "All required information available, starting subscription process." );
   try_subscribe();
-  if (!is_subscribed_) subscribe_timer_.start();
+  if ( !is_subscribed_ )
+    subscribe_timer_.start();
 }
 
 void Subscription::try_subscribe()

--- a/src/subscription.cpp
+++ b/src/subscription.cpp
@@ -138,8 +138,8 @@ void Subscription::subscribe()
   }
 
   QML_ROS2_PLUGIN_DEBUG( "All required information available, starting subscription process." );
-  subscribe_timer_.start();
   try_subscribe();
+  if (!is_subscribed_) subscribe_timer_.start();
 }
 
 void Subscription::try_subscribe()

--- a/test/communication.cpp
+++ b/test/communication.cpp
@@ -323,7 +323,7 @@ TEST( Communication, serviceCallAsync )
   delete service;
 
   service = dynamic_cast<ServiceClient *>(
-      wrapper.createServiceClient( "/service_empty", "std_srvs/srv/Empty" ) );
+      wrapper.createServiceClient( "/service_empty", "std_srvs/srv/Empty", {} ) );
   engine.newQObject( service );
   ASSERT_NE( service, nullptr );
   service_called = false;

--- a/test/communication.cpp
+++ b/test/communication.cpp
@@ -46,14 +46,14 @@ void processEvents()
   rclcpp::spin_some( node );
 }
 
-//! @param wait_count Max time to wait in increments of 33 ms
-bool waitFor( const std::function<bool()> &pred, int wait_count = 10 )
+bool waitFor( const std::function<bool()> &pred, std::chrono::milliseconds timeout = 500ms )
 {
-  while ( --wait_count > 0 ) {
+  auto start = std::chrono::steady_clock::now();
+  while ( ( std::chrono::steady_clock::now() - start ) < timeout ) {
     if ( pred() )
       return true;
     processEvents();
-    std::this_thread::sleep_for( 33ms );
+    std::this_thread::sleep_for( 1ms );
   }
   return false;
 }
@@ -96,7 +96,7 @@ TEST( Communication, publisher )
       "/pose", 10, [&pub_singleton_glob_explicit_storage]( geometry_msgs::msg::Pose::UniquePtr msg ) {
         pub_singleton_glob_explicit_storage.callback( *msg );
       } );
-  waitFor( []() { return false; }, 16 ); // Wait for half a second
+  waitFor( []() { return false; }, 500ms ); // Wait for half a second
   EXPECT_TRUE( pub_singleton_glob_explicit_storage.messages.empty() );
   pub_singleton_glob_explicit->publish( { { "position", QVariantMap{ { "y", 1.3 } } } } );
   if ( !waitFor( [&]() { return !pub_singleton_glob_explicit_storage.messages.empty(); } ) )
@@ -114,7 +114,7 @@ TEST( Communication, publisher )
       "/other_pose", 10, [&pub_singleton_glob_storage]( geometry_msgs::msg::Pose::UniquePtr msg ) {
         pub_singleton_glob_storage.callback( *msg );
       } );
-  waitFor( []() { return false; }, 16 ); // Wait for half a second
+  waitFor( []() { return false; }, 500ms ); // Wait for half a second
   EXPECT_TRUE( pub_singleton_glob_storage.messages.empty() );
   pub_singleton_glob->publish( { { "position", QVariantMap{ { "y", 1.3 } } } } );
   if ( !waitFor( [&]() { return !pub_singleton_glob_storage.messages.empty(); } ) )
@@ -134,8 +134,7 @@ TEST( Communication, subscriber )
   processEvents();
   EXPECT_TRUE( subscriber_pns->isRosInitialized() );
   EXPECT_TRUE( subscriber_pns->enabled() );
-  EXPECT_TRUE(
-      waitFor( [&subscriber_pns]() { return subscriber_pns->getPublisherCount() == 1U; }, 10 ) );
+  EXPECT_TRUE( waitFor( [&subscriber_pns]() { return subscriber_pns->getPublisherCount() == 1U; } ) );
   ASSERT_EQ( subscriber_pns->topic().toStdString(), "/communication/test" );
   //  EXPECT_EQ( subscriber_pns->ns(), QString( "/communication/private_ns" )) << subscriber_pns->ns().toStdString();
   EXPECT_EQ( subscriber_pns->queueSize(), 1U );
@@ -235,8 +234,7 @@ TEST( Communication, throttleRate )
   processEvents();
   EXPECT_TRUE( subscriber_pns->isRosInitialized() );
   EXPECT_TRUE( subscriber_pns->enabled() );
-  EXPECT_TRUE(
-      waitFor( [&subscriber_pns]() { return subscriber_pns->getPublisherCount() == 1U; }, 10 ) );
+  EXPECT_TRUE( waitFor( [&subscriber_pns]() { return subscriber_pns->getPublisherCount() == 1U; } ) );
   ASSERT_EQ( subscriber_pns->topic().toStdString(), "/communication/test_throttle_rate" );
   EXPECT_EQ( subscriber_pns->queueSize(), 5U );
   if ( !waitFor( [&]() { return pub_pns->get_subscription_count() > 0; } ) )
@@ -291,28 +289,24 @@ TEST( Communication, queryTopics )
   auto pub6 = node->create_publisher<geometry_msgs::msg::Pose>( "/query_topics/pose3", 10 );
   Ros2QmlSingletonWrapper wrapper;
   ASSERT_TRUE(
-      waitFor( [&wrapper]() { return !wrapper.queryTopics().empty(); }, 30 ) ); // Wait for topics
+      waitFor( [&wrapper]() { return !wrapper.queryTopics().empty(); }, 1s ) ); // Wait for topics
   for ( const QString &topic :
         QStringList{ "/query_topics/pose1", "/query_topics/vector3", "/query_topics/point1",
                      "/query_topics/point2", "/query_topics/pose2", "/query_topics/pose3" } ) {
-    ASSERT_TRUE( waitFor( [&wrapper, &topic]() { return wrapper.queryTopics().contains( topic ); }, 10 ) )
+    ASSERT_TRUE( waitFor( [&wrapper, &topic]() { return wrapper.queryTopics().contains( topic ); } ) )
         << topic.toStdString() << " is not in topics.";
   }
   for ( const QString &topic : QStringList{ "/query_topics/point1", "/query_topics/point2" } ) {
-    ASSERT_TRUE( waitFor(
-        [&wrapper, &topic]() {
-          return wrapper.queryTopics( "geometry_msgs/Point" ).contains( topic );
-        },
-        10 ) )
+    ASSERT_TRUE( waitFor( [&wrapper, &topic]() {
+      return wrapper.queryTopics( "geometry_msgs/Point" ).contains( topic );
+    } ) )
         << topic.toStdString() << " is not in topics of type Point.";
   }
   for ( const QString &topic :
         QStringList{ "/query_topics/pose1", "/query_topics/pose2", "/query_topics/pose3" } ) {
-    ASSERT_TRUE( waitFor(
-        [&wrapper, &topic]() {
-          return wrapper.queryTopics( "geometry_msgs/msg/Pose" ).contains( topic );
-        },
-        10 ) )
+    ASSERT_TRUE( waitFor( [&wrapper, &topic]() {
+      return wrapper.queryTopics( "geometry_msgs/msg/Pose" ).contains( topic );
+    } ) )
         << topic.toStdString() << " is not in topics of type Pose.";
   }
   QList<TopicInfo> topic_info = wrapper.queryTopicInfo();
@@ -379,7 +373,7 @@ TEST( Communication, serviceCallAsync )
   ASSERT_TRUE( waitFor( [&]() { return service->isServiceReady(); } ) );
   service->sendRequestAsync( { { "a", 1 }, { "b", 3 } }, callback );
   ASSERT_TRUE( !returned );
-  waitFor( [&returned]() { return returned; }, 60 );
+  waitFor( [&returned]() { return returned; }, 2s );
   ASSERT_TRUE( returned );
   processEvents();
   ASSERT_TRUE( obj.hasProperty( "result" ) );
@@ -521,7 +515,7 @@ return {
 }
 }))!" )
                          .call( { callback_watcher_js } );
-  ASSERT_TRUE( waitFor( [&client]() { return client.isServerReady(); }, 150 ) ); // Wait max 5 seconds
+  ASSERT_TRUE( waitFor( [&client]() { return client.isServerReady(); }, 5s ) );
   GoalHandle *handle =
       dynamic_cast<GoalHandle *>( client.sendGoalAsync( { { "target", 400 } }, options ) );
   //  ASSERT_NE( handle, nullptr );
@@ -529,7 +523,7 @@ return {
   handle = callback_watcher->goal_handles[0];
   //  EXPECT_EQ( handle->status(), action_goal_status::Executing );
   ASSERT_TRUE(
-      waitFor( [&handle]() { return handle->status() == action_goal_status::Succeeded; }, 90 ) );
+      waitFor( [&handle]() { return handle->status() == action_goal_status::Succeeded; }, 3s ) );
   EXPECT_EQ( callback_watcher->feedback, 401 );
 
   ASSERT_TRUE( waitFor( [&callback_watcher, handle]() {
@@ -586,11 +580,11 @@ return {
   //  EXPECT_TRUE( waitFor( [ &handle3 ]() { return handle3->status() == action_goal_status::Executing; } ));
   std::this_thread::sleep_for( 5ms );
   client.cancelAllGoals();
-  EXPECT_TRUE( waitFor( [&handle1]() { return handle1->status() == action_goal_status::Canceled; }, 150 ) )
+  EXPECT_TRUE( waitFor( [&handle1]() { return handle1->status() == action_goal_status::Canceled; }, 5s ) )
       << handle1->status();
-  EXPECT_TRUE( waitFor( [&handle2]() { return handle2->status() == action_goal_status::Canceled; }, 150 ) )
+  EXPECT_TRUE( waitFor( [&handle2]() { return handle2->status() == action_goal_status::Canceled; }, 5s ) )
       << handle2->status();
-  EXPECT_TRUE( waitFor( [&handle3]() { return handle3->status() == action_goal_status::Canceled; }, 150 ) )
+  EXPECT_TRUE( waitFor( [&handle3]() { return handle3->status() == action_goal_status::Canceled; }, 5s ) )
       << handle3->status();
   //  delete handle1;
   //  delete handle2;
@@ -598,33 +592,30 @@ return {
 
   // Cancel all goals before and at time
   callback_watcher->goal_handles.clear();
-  handle1 = dynamic_cast<GoalHandle *>( client.sendGoalAsync( { { "target", 700 } }, options ) );
+  handle1 = dynamic_cast<GoalHandle *>( client.sendGoalAsync( { { "target", 1700 } }, options ) );
   //  ASSERT_NE( handle1, nullptr );
   processEvents();
-  std::this_thread::sleep_for( 5ms );
-  handle2 = dynamic_cast<GoalHandle *>( client.sendGoalAsync( { { "target", 800 } }, options ) );
+  std::this_thread::sleep_for( 10ms );
+  processEvents();
+  handle2 = dynamic_cast<GoalHandle *>( client.sendGoalAsync( { { "target", 1800 } }, options ) );
   //  ASSERT_NE( handle2, nullptr );
   processEvents();
-  std::this_thread::sleep_for( 5ms );
+  std::this_thread::sleep_for( 40ms );
   processEvents();
   QDateTime now = rosToQmlTime( node->now() );
-  std::this_thread::sleep_for( 5ms );
+  std::this_thread::sleep_for( 10ms );
+  processEvents();
   handle3 = dynamic_cast<GoalHandle *>( client.sendGoalAsync( { { "target", 190 } }, options ) );
-  //  ASSERT_NE( handle3, nullptr );
-  ASSERT_TRUE(
-      waitFor( [&callback_watcher]() { return callback_watcher->goal_handles.size() == 3; } ) );
-  handle1 = callback_watcher->goal_handles[0];
-  handle2 = callback_watcher->goal_handles[1];
-  handle3 = callback_watcher->goal_handles[2];
+  ASSERT_NE( handle3, nullptr );
   EXPECT_NE( handle1->status(), action_goal_status::Succeeded );
   EXPECT_NE( handle2->status(), action_goal_status::Succeeded );
   EXPECT_NE( handle3->status(), action_goal_status::Succeeded );
   client.cancelGoalsBefore( now );
-  EXPECT_TRUE( waitFor( [&handle1]() { return handle1->status() == action_goal_status::Canceled; }, 20 ) )
+  EXPECT_TRUE( waitFor( [&handle1]() { return handle1->status() == action_goal_status::Canceled; }, 2s ) )
       << handle1->status();
-  EXPECT_TRUE( waitFor( [&handle2]() { return handle2->status() == action_goal_status::Canceled; }, 20 ) )
+  EXPECT_TRUE( waitFor( [&handle2]() { return handle2->status() == action_goal_status::Canceled; }, 2s ) )
       << handle2->status();
-  EXPECT_TRUE( waitFor( [&handle3]() { return handle3->status() == action_goal_status::Succeeded; }, 20 ) )
+  EXPECT_TRUE( waitFor( [&handle3]() { return handle3->status() == action_goal_status::Succeeded; }, 2s ) )
       << handle3->status();
 
   ASSERT_TRUE( waitFor( [&callback_watcher, handle3]() {


### PR DESCRIPTION
This adds the ability to configure QoS settings, which is especially useful for a `Subscription` where you want to receive one or multiple `transient_local` messages.

Also updated the `throttleRate` logic, which was necessary to support the receiving of multiple messages.
For this, the `throttleRate` has to be set to 0.
With the `throttleRate` set to 0 and a QoS setting of `transient_local` and a `keep_last(5)` history policy, it is now possible to receive and process all of the last 5 published messages of a publisher.

Example:

```qml
Subscription {
  topic: "robot_announcement"
  messageType: "hector_multi_robot_msgs/msg/RobotAnnouncement"
  qos: Ros2.QoS().transient_local().reliable()
  onNewMessage: {
    // process message
  }
}
```